### PR TITLE
Add memory limit option for FaceMerger

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ Frequently asked questions
 
 <a href="doc/developer_faq/developer_faq.md">for Developer</a>
 </td></tr>
+<tr><td align="right">
+Environment variables
+</td><td align="left">
+<code>DFL_FACE_MERGER_MEM_MB</code> &mdash; set GPU memory limit for FaceMerger (in MB)
+</td></tr>
 <tr><td colspan=2 align="center">
 
 ## Releases

--- a/apps/DeepFaceLive/backend/FaceMerger.py
+++ b/apps/DeepFaceLive/backend/FaceMerger.py
@@ -1,4 +1,5 @@
 import time
+import os
 
 import cv2
 import numexpr as ne
@@ -27,6 +28,14 @@ class FaceMerger(BackendHost):
     def get_control_sheet(self) -> 'Sheet.Host': return super().get_control_sheet()
 
 class FaceMergerWorker(BackendWorker):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        env_limit = os.getenv('DFL_FACE_MERGER_MEM_MB')
+        try:
+            self.memory_limit_mb = int(env_limit) if env_limit is not None else 512
+        except ValueError:
+            self.memory_limit_mb = 512
+
     def get_state(self) -> 'WorkerState': return super().get_state()
     def get_control_sheet(self) -> 'Sheet.Worker': return super().get_control_sheet()
 
@@ -42,6 +51,7 @@ class FaceMergerWorker(BackendWorker):
 
         state, cs = self.get_state(), self.get_control_sheet()
         cs.device.call_on_selected(self.on_cs_device)
+        cs.memory_limit_mb.call_on_number(self.on_cs_memory_limit_mb)
         cs.face_x_offset.call_on_number(self.on_cs_face_x_offset)
         cs.face_y_offset.call_on_number(self.on_cs_face_y_offset)
         cs.face_scale.call_on_number(self.on_cs_face_scale)
@@ -61,12 +71,21 @@ class FaceMergerWorker(BackendWorker):
         cs.device.set_choices( ['CPU'] + lib_cl.get_available_devices_info(), none_choice_name='@misc.menu_select')
         cs.device.select(state.device if state.device is not None else 'CPU')
 
+        if state.memory_limit_mb is None:
+            state.memory_limit_mb = self.memory_limit_mb
+        else:
+            self.memory_limit_mb = state.memory_limit_mb
+
+        cs.memory_limit_mb.enable()
+        cs.memory_limit_mb.set_config(lib_csw.Number.Config(min=128, max=8192, step=64, decimals=0, allow_instant_update=True))
+        cs.memory_limit_mb.set_number(state.memory_limit_mb)
+
     def on_cs_device(self, idxs, device : lib_cl.DeviceInfo):
         state, cs = self.get_state(), self.get_control_sheet()
         if device is not None and state.device == device:
             if device != 'CPU':
                 dev = lib_cl.get_device(device)
-                dev.set_target_memory_usage(mb=512)
+                dev.set_target_memory_usage(mb=self.memory_limit_mb)
                 lib_cl.set_default_device(dev)
 
             cs.face_x_offset.enable()
@@ -117,6 +136,17 @@ class FaceMergerWorker(BackendWorker):
             state.device = device
             self.save_state()
             self.restart()
+
+    def on_cs_memory_limit_mb(self, memory_limit_mb):
+        state, cs = self.get_state(), self.get_control_sheet()
+        cfg = cs.memory_limit_mb.get_config()
+        memory_limit_mb = int(np.clip(memory_limit_mb, cfg.min, cfg.max))
+        state.memory_limit_mb = self.memory_limit_mb = memory_limit_mb
+        cs.memory_limit_mb.set_number(memory_limit_mb)
+        self.save_state()
+        if state.device and state.device != 'CPU':
+            dev = lib_cl.get_device(state.device)
+            dev.set_target_memory_usage(mb=memory_limit_mb)
 
     def on_cs_face_x_offset(self, face_x_offset):
         state, cs = self.get_state(), self.get_control_sheet()
@@ -379,6 +409,7 @@ class Sheet:
         def __init__(self):
             super().__init__()
             self.device = lib_csw.DynamicSingleSwitch.Client()
+            self.memory_limit_mb = lib_csw.Number.Client()
             self.face_x_offset = lib_csw.Number.Client()
             self.face_y_offset = lib_csw.Number.Client()
             self.face_scale = lib_csw.Number.Client()
@@ -400,6 +431,7 @@ class Sheet:
         def __init__(self):
             super().__init__()
             self.device = lib_csw.DynamicSingleSwitch.Host()
+            self.memory_limit_mb = lib_csw.Number.Host()
             self.face_x_offset = lib_csw.Number.Host()
             self.face_y_offset = lib_csw.Number.Host()
             self.face_scale = lib_csw.Number.Host()
@@ -417,6 +449,7 @@ class Sheet:
 
 class WorkerState(BackendWorkerState):
     device : lib_cl.DeviceInfo = None
+    memory_limit_mb : int = None
     face_x_offset : float = None
     face_y_offset : float = None
     face_scale : float = None

--- a/apps/DeepFaceLive/ui/QFaceMerger.py
+++ b/apps/DeepFaceLive/ui/QFaceMerger.py
@@ -17,6 +17,9 @@ class QFaceMerger(QBackendPanel):
         q_device_label = QLabelPopupInfo(label=L('@common.device'), popup_info_text=L('@common.help.device'))
         q_device       = QComboBoxCSWDynamicSingleSwitch(cs.device, reflect_state_widgets=[q_device_label])
 
+        q_memory_limit_label = QLabelPopupInfo(label=L('@QFaceMerger.memory_limit_mb'))
+        q_memory_limit       = QSpinBoxCSWNumber(cs.memory_limit_mb, reflect_state_widgets=[q_memory_limit_label])
+
         q_face_x_offset_label = QLabelPopupInfo(label=L('@QFaceMerger.face_x_offset'))
         q_face_x_offset       = QSpinBoxCSWNumber(cs.face_x_offset, reflect_state_widgets=[q_face_x_offset_label])
 
@@ -56,6 +59,9 @@ class QFaceMerger(QBackendPanel):
         row = 0
         grid_l.addWidget(q_device_label, row, 0, alignment=qtx.AlignRight | qtx.AlignVCenter)
         grid_l.addWidget(q_device, row, 1, alignment=qtx.AlignLeft )
+        row += 1
+        grid_l.addWidget(q_memory_limit_label, row, 0, alignment=qtx.AlignRight | qtx.AlignVCenter)
+        grid_l.addWidget(q_memory_limit, row, 1, alignment=qtx.AlignLeft )
         row += 1
         grid_l.addLayout( qtx.QXVBoxLayout([q_face_x_offset_label, q_face_y_offset_label]), row, 0, alignment=qtx.AlignRight | qtx.AlignVCenter)
         grid_l.addLayout( qtx.QXHBoxLayout([q_face_x_offset, q_face_y_offset]), row, 1, alignment=qtx.AlignLeft )

--- a/localization/localization.py
+++ b/localization/localization.py
@@ -1060,6 +1060,15 @@ class Localization:
                 'ja-JP' : '色圧縮',
                 'de-DE' : 'Farbkompression'},
 
+    'QFaceMerger.memory_limit_mb':{
+                'en-US' : 'GPU memory limit, MB',
+                'ru-RU' : 'Лимит памяти ГП, МБ',
+                'zh-CN' : 'GPU 内存限制，MB',
+                'es-ES' : 'Límite de memoria GPU, MB',
+                'it-IT' : 'Limite memoria GPU, MB',
+                'ja-JP' : 'GPU メモリ上限 (MB)',
+                'de-DE' : 'GPU Speicherlimit, MB'},
+
     'QFaceMerger.face_opacity':{
                 'en-US' : 'Face opacity',
                 'ru-RU' : 'Непрозрач. лица',


### PR DESCRIPTION
## Summary
- make FaceMerger GPU memory limit configurable
- expose memory limit in the FaceMerger UI
- document `DFL_FACE_MERGER_MEM_MB` environment variable

## Testing
- `python -m py_compile apps/DeepFaceLive/backend/FaceMerger.py apps/DeepFaceLive/ui/QFaceMerger.py localization/localization.py`

------
https://chatgpt.com/codex/tasks/task_e_68402ca02ba883328f12a60c5114f24e